### PR TITLE
[Bad username / password! ] bug fixed

### DIFF
--- a/src/SendCloudServiceProvider.php
+++ b/src/SendCloudServiceProvider.php
@@ -17,6 +17,10 @@ class SendCloudServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->mergeConfigFrom(
+            dirname(__DIR__).'/config/services.php', 'services'
+        );
+        
         $this->app->resolving('swift.transport', function (TransportManager $tm) {
             $tm->extend('sendcloud', function () {
                 $api_user = config('services.sendcloud.api_user');
@@ -29,8 +33,6 @@ class SendCloudServiceProvider extends ServiceProvider
 
     public function boot()
     {
-        $this->mergeConfigFrom(
-            dirname(__DIR__).'/config/services.php', 'services'
-        );
+        
     }
 }


### PR DESCRIPTION
Laravel启动的时候是先执行全部ServiceProvider的register之后，再调用boot方法，这里需要先合并配置文件，闭包里面的extend中的closeure里面才能取得config。

要不你这个地方的config文件就得弄成可以pulish的，这样可以 php artisan vendor:publish 发布配置文件，那样就不需要合并配置文件了。
